### PR TITLE
fix(crux): guard null tracker component in Crux Resonator use()

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/item/custom/crux_resonator/CruxResonator.java
+++ b/src/main/java/net/ugi/sculk_depths/item/custom/crux_resonator/CruxResonator.java
@@ -47,6 +47,11 @@ public class CruxResonator extends Item {
         ItemStack itemStack = user.getStackInHand(hand);
         if(world.isClient) {return TypedActionResult.pass(itemStack);}//maybe fix some bugs?
         OscillatorTrackerComponentList oscillatorTrackerComponentList = itemStack.get(ModComponentTypes.OSCILLATOR_TRACKER_LIST);
+        if (oscillatorTrackerComponentList == null) {
+            //fresh resonator: no tracked locations yet, initialize an empty tracker list
+            itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST, new OscillatorTrackerComponentList(0, List.of()));
+            return TypedActionResult.success(itemStack,false);
+        }
         System.out.println(oscillatorTrackerComponentList.selectedLocation());
         itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST, new OscillatorTrackerComponentList(oscillatorTrackerComponentList.selectedLocation() +1, oscillatorTrackerComponentList.trackers()));
         return TypedActionResult.success(itemStack,false);

--- a/src/test/java/net/ugi/sculk_depths/item/Issue87CruxResonatorFreshStackTest.java
+++ b/src/test/java/net/ugi/sculk_depths/item/Issue87CruxResonatorFreshStackTest.java
@@ -1,4 +1,4 @@
-package net.ugi.sculk_depths.regression;
+package net.ugi.sculk_depths.item;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -23,8 +23,9 @@ import static org.mockito.Mockito.when;
  * Crux Resonator has no such component, so get() returns null and the call
  * throws a NullPointerException.
  *
- * Asserts the CORRECT behavior (using a fresh resonator succeeds), so it FAILS
- * on the current buggy code with an NPE. That failure is the expected proof.
+ * Asserts the CORRECT behavior (using a fresh resonator succeeds and leaves an
+ * initialized tracker list on the stack). Fixed in the production code; this test
+ * is kept as a permanent regression guard in the main suite.
  */
 class Issue87CruxResonatorFreshStackTest {
 


### PR DESCRIPTION
A freshly crafted Crux Resonator carries no `OSCILLATOR_TRACKER_LIST` component, and `use()` dereferences it without a guard, throwing an NPE on the first right-click. `inventoryTick`, `getTrackedPos` and `appendTooltip` already null-guard this component — `use()` did not.

This guards the component in `use()` and returns cleanly when there are no tracked locations.

The regression test covering this moves out of the opt-in `regressionTest` task into the main `test` suite, so it now runs as a permanent guard.

Fixes #87

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
