### PR TITLE
fix(datagen): pass the END/SIDE texture map to the CUBE_COLUMN upload

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/datagen/ModModelProvider.java
+++ b/src/main/java/net/ugi/sculk_depths/datagen/ModModelProvider.java
@@ -131,8 +131,7 @@ public class ModModelProvider extends FabricModelProvider {
 
             identifierList.add(ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE, suffix));
             TextureMap textureMap = (new TextureMap()).put(TextureKey.END,ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE, "_end" + suffix)).put(TextureKey.SIDE,ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE, "_side" + suffix));
-            TextureMap textureMap1 = TextureMap.of(TextureKey.TEXTURE, ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE,  suffix));
-            model.upload(ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE, suffix), textureMap1, blockStateModelGenerator.modelCollector);
+            model.upload(ModelIds.getBlockSubModelId(ModBlocks.AMALGAMITE, suffix), textureMap, blockStateModelGenerator.modelCollector);
         });
 
         blockStateModelGenerator.blockStateCollector.accept(createBlockStateWithVariants(block,identifierList));


### PR DESCRIPTION
`./gradlew runDatagen` failed with `IllegalStateException: Can't find texture for slot #end`. `ModModelProvider` builds `textureMap` with `TextureKey.END` + `TextureKey.SIDE` (correct for `Models.CUBE_COLUMN`) but passes `textureMap1` (TEXTURE-only) to `model.upload(...)`.

This passes `textureMap`. `runDatagen` now completes successfully.

Fixes #88

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
