### PR TITLE
fix(cauldron): consume the ingot used, not the offhand stack

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/block/custom/ModCauldron/ModCauldronBehavior.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/ModCauldron/ModCauldronBehavior.java
@@ -114,9 +114,7 @@ public interface ModCauldronBehavior {
             }
             if (!world.isClient) {
                 if (!player.isCreative()) {
-                    ItemStack heldItem = player.getMainHandStack().getItem() == ModItems.CRUX ?
-                            player.getMainHandStack() : player.getOffHandStack();
-                    heldItem.decrement(1);
+                    stack.decrement(1);
                 }
                 player.incrementStat(Stats.USE_CAULDRON);
                 player.incrementStat(Stats.USED.getOrCreateStat(stack.getItem()));

--- a/src/test/java/net/ugi/sculk_depths/block/Issue89CauldronConsumesOffhandTest.java
+++ b/src/test/java/net/ugi/sculk_depths/block/Issue89CauldronConsumesOffhandTest.java
@@ -1,4 +1,4 @@
-package net.ugi.sculk_depths.regression;
+package net.ugi.sculk_depths.block;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.cauldron.CauldronBehavior;
@@ -31,8 +31,9 @@ import static org.mockito.Mockito.when;
  * stack to decrement, so using an ingot from the main hand consumes the OFFHAND
  * stack instead of the ingot.
  *
- * Asserts the CORRECT behavior (the ingot stack is consumed, offhand untouched),
- * so it FAILS on the current buggy code. That failure is the expected proof.
+ * Asserts the CORRECT behavior (the ingot stack is consumed, offhand untouched).
+ * Fixed in the production code; this test is kept as a permanent regression
+ * guard in the main suite.
  */
 class Issue89CauldronConsumesOffhandTest {
 


### PR DESCRIPTION
The Quazarith ingot cauldron behavior chose the stack to consume with a `== ModItems.CRUX` test (copy-pasted from the CRUX handler), so holding the ingot in the main hand made the condition false and it decremented the **offhand** instead — the ingot was never consumed and an unrelated offhand item was destroyed.

This consumes the stack actually used in the interaction.

The regression test moves into the main `test` suite.

Fixes #89

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
