### PR TITLE
fix(furnace): correct quickMove slot ranges for the 2-slot Zygrin furnace

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/screen/AbstractZygrinFurnaceScreenHandler.java
+++ b/src/main/java/net/ugi/sculk_depths/screen/AbstractZygrinFurnaceScreenHandler.java
@@ -107,12 +107,32 @@ public class AbstractZygrinFurnaceScreenHandler extends AbstractRecipeScreenHand
         if (slot2 != null && slot2.hasStack()) {
             ItemStack itemStack2 = slot2.getStack();
             itemStack = itemStack2.copy();
-            if (slot == 2) {
-                if (!this.insertItem(itemStack2, 3, 38, true)) {
+            if (slot == 1) {
+                //output slot -> player inventory (handler slots 2-37)
+                if (!this.insertItem(itemStack2, 2, 38, true)) {
                     return ItemStack.EMPTY;
                 }
                 slot2.onQuickTransfer(itemStack2, itemStack);
-            } else if (slot == 1 || slot == 0 ? !this.insertItem(itemStack2, 3, 38, false) : (this.isSmeltable(itemStack2) ? !this.insertItem(itemStack2, 0, 1, false) : (this.isFuel(itemStack2) ? !this.insertItem(itemStack2, 1, 2, false) : (slot >= 3 && slot < 30 ? !this.insertItem(itemStack2, 30, 38, false) : slot >= 30 && slot < 39 && !this.insertItem(itemStack2, 3, 30, false))))) {
+            } else if (slot == 0) {
+                //input slot -> player inventory
+                if (!this.insertItem(itemStack2, 2, 38, false)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (this.isSmeltable(itemStack2)) {
+                if (!this.insertItem(itemStack2, 0, 1, false)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (this.isFuel(itemStack2)) {
+                //the fuel slot (furnace inventory index 1) has no handler slot,
+                //so insertItem cannot reach it; insert the fuel directly
+                if (!this.insertIntoFuelSlot(itemStack2)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (slot >= 2 && slot < 29) {
+                if (!this.insertItem(itemStack2, 29, 38, false)) {
+                    return ItemStack.EMPTY;
+                }
+            } else if (slot >= 29 && slot < 38 && !this.insertItem(itemStack2, 2, 29, false)) {
                 return ItemStack.EMPTY;
             }
             if (itemStack2.isEmpty()) {
@@ -126,6 +146,26 @@ public class AbstractZygrinFurnaceScreenHandler extends AbstractRecipeScreenHand
             slot2.onTakeItem(player, itemStack2);
         }
         return itemStack;
+    }
+
+    private boolean insertIntoFuelSlot(ItemStack stack) {
+        ItemStack fuelStack = this.inventory.getStack(1);
+        if (fuelStack.isEmpty()) {
+            this.inventory.setStack(1, stack.copy());
+            this.inventory.markDirty();
+            stack.setCount(0);
+            return true;
+        }
+        if (ItemStack.areItemsAndComponentsEqual(fuelStack, stack)) {
+            int i = Math.min(stack.getCount(), Math.min(fuelStack.getMaxCount(), this.inventory.getMaxCount(fuelStack)) - fuelStack.getCount());
+            if (i > 0) {
+                fuelStack.increment(i);
+                stack.decrement(i);
+                this.inventory.markDirty();
+                return true;
+            }
+        }
+        return false;
     }
 
     protected boolean isSmeltable(ItemStack itemStack) {

--- a/src/test/java/net/ugi/sculk_depths/screen/Issue93FurnaceQuickMoveTest.java
+++ b/src/test/java/net/ugi/sculk_depths/screen/Issue93FurnaceQuickMoveTest.java
@@ -1,4 +1,4 @@
-package net.ugi.sculk_depths.regression;
+package net.ugi.sculk_depths.screen;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -32,8 +32,9 @@ import static org.mockito.Mockito.*;
  * which is actually the output slot and refuses insertion — and the fuel never
  * reaches the fuel slot.
  *
- * Asserts the CORRECT behavior (fuel lands in furnace inventory slot 1), so it
- * FAILS on the current buggy code. That failure is the expected proof.
+ * Asserts the CORRECT behavior (fuel lands in furnace inventory slot 1).
+ * Fixed in the production code; this test is kept as a permanent regression
+ * guard in the main suite.
  */
 class Issue93FurnaceQuickMoveTest {
 


### PR DESCRIPTION
`AbstractZygrinFurnaceScreenHandler` exposes two container slots (0 = input, 1 = output) with the player inventory starting at handler index 2, but `quickMove` used vanilla's 3-slot furnace ranges: it treated slot 2 (a player slot) as the output, started the player destination range at 3 (so index 2 was never a valid destination), and routed fuel into slot 1 (the output).

This corrects the ranges for the actual layout and routes fuel to the furnace inventory's fuel slot. It also adds the `markDirty()` that was missing on the empty-fuel-slot insertion path, matching the stack-merge path.

The regression test moves into the main `test` suite.

Fixes #93

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
