### PR TITLE
fix(lester): don't let a failed roof lookup null out pos in the spawn loop

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/block/custom/LesterSpawningBlock.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/LesterSpawningBlock.java
@@ -42,13 +42,15 @@ public class LesterSpawningBlock extends Block {
             pos = pos.east(XOffset);
             int ZOffset = MathHelper.nextInt(Random.create(), -5, 5);
             pos = pos.south(ZOffset);
+            BlockPos candidate;
             if(!world.getBlockState(pos).isIn(ModTags.Blocks.LESTER_SPAWN_BLOCKS)){
-                pos = checkForRoof(world,pos, "Up",0,300);
+                candidate = checkForRoof(world,pos, "Up",0,300);
             }
-            else pos = checkForRoof(world,pos, "Down",0,10);
+            else candidate = checkForRoof(world,pos, "Down",0,10);
 
 
-            if(pos == null){ continue;}
+            if(candidate == null){ continue;}
+            pos = candidate;
 
 
             entity.setPosition(pos.getX()+ 0.5,pos.getY()+0.99,pos.getZ() + 0.5);


### PR DESCRIPTION
Breaking a Lester-spawning block can crash with an NPE. Inside `onBroken`'s spawn loop, `pos` is reassigned from `checkForRoof(...)`, which returns null when no spawn block is found within range. That null is only handled by a bare `continue`, which leaves `pos` null — so the first statement of the *next* iteration, `pos = pos.east(XOffset)`, dereferences it and throws.

This holds the lookup result in a candidate and only commits it to `pos` when non-null, so a failed lookup skips that spawn cleanly instead of poisoning the next iteration.

Fixes #92

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
