### PR TITLE
fix(portal): guard structure resolution and placement failure during ignition

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
@@ -148,6 +148,8 @@ public class PedestalBlock extends FacingBlock {
 
                 structureStart = GenerateStructureAPI.structureStart(world, ModDimensions.SCULK_DEPTHS_LEVEL_KEY, SculkDepths.identifier("portal_structure"), anchor); //50ms (matteo)
 
+                if (structureStart == null || !structureStart.hasChildren()) {portalFase = "none";return;}
+
                 BlockBox boundingBox = structureStart.getBoundingBox();
                 structureStart.getChildren().stream().forEach(child -> {
                     System.out.println(child.getBoundingBox());

--- a/src/main/java/net/ugi/sculk_depths/portal/GenerateStructureAPI.java
+++ b/src/main/java/net/ugi/sculk_depths/portal/GenerateStructureAPI.java
@@ -73,7 +73,9 @@ public class GenerateStructureAPI {
 
     public static StructureStart structureStart (World  originalWorld, RegistryKey<World> targetWorldKey, Identifier structureKey, BlockPos pos){
         if(originalWorld.isClient)return null;
-        RegistryEntry.Reference<Structure> structure = originalWorld.getRegistryManager().get(RegistryKeys.STRUCTURE).getEntry(structureKey).get();
+        Optional<RegistryEntry.Reference<Structure>> structureReference = originalWorld.getRegistryManager().get(RegistryKeys.STRUCTURE).getEntry(structureKey);
+        if(structureReference.isEmpty())return null;
+        RegistryEntry.Reference<Structure> structure = structureReference.get();
         ServerWorld serverWorld = originalWorld.getServer().getWorld(targetWorldKey);
         ChunkGenerator chunkGenerator = serverWorld.getChunkManager().getChunkGenerator();
         Structure structure2 = structure.value();


### PR DESCRIPTION
Two unguarded spots could throw during portal ignition instead of failing gracefully:

- `GenerateStructureAPI.structureStart(...)` called `.get()` directly on the registry `Optional`, throwing `NoSuchElementException` if the structure isn't registered.
- The caller read `getBoundingBox()` / `getChildren()` before any children check, so a childless `StructureStart` (structure can't place at that location) gave a null bounding box and an NPE.

This guards both: the registry lookup returns null rather than throwing, and ignition aborts cleanly — resetting the phase the same way the other early-abort paths in that state machine do — when the start is null or has no children. It mirrors the `hasChildren()` check the sibling `generate(...)` helper already does.

Fixes #95

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
