### PR TITLE
chore: remove debug System.out.println from gameplay paths

### DIFF
--- a/src/client/java/net/ugi/sculk_depths/sound/ConditionalSoundPlayerClient.java
+++ b/src/client/java/net/ugi/sculk_depths/sound/ConditionalSoundPlayerClient.java
@@ -192,7 +192,6 @@ public class ConditionalSoundPlayerClient implements ClientTickEvents.StartWorld
 
         DensityFunction.Noise radNoise = new DensityFunction.Noise(noiseParam, DoublePerlinNoiseSampler.create(radRandom, new DoublePerlinNoiseSampler.NoiseParameters(-7, 1,2,3,2,4,2.4,9)));
         DensityFunction.Noise speedNoise = new DensityFunction.Noise(noiseParam, DoublePerlinNoiseSampler.create(speedRandom, new DoublePerlinNoiseSampler.NoiseParameters(-7, 1,2,3,2,4,2.4,9)));
-        System.out.println(world.getTime());
         double rad = radNoise.sample(player.getX()/75d, world.getTime()/600d, player.getZ()/75d)*Math.PI;
         double speed = speedNoise.sample(player.getX()/75d, world.getTime()/300d, player.getZ()/75d);
 

--- a/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
@@ -149,10 +149,6 @@ public class PedestalBlock extends FacingBlock {
                 structureStart = GenerateStructureAPI.structureStart(world, ModDimensions.SCULK_DEPTHS_LEVEL_KEY, SculkDepths.identifier("portal_structure"), anchor); //50ms (matteo)
 
                 BlockBox boundingBox = structureStart.getBoundingBox();
-                structureStart.getChildren().stream().forEach(child -> {
-                    System.out.println(child.getBoundingBox());
-                });
-
                 chunkArray = GenerateStructureAPI.generateChunkArray(//not laggy
                         new ChunkPos(ChunkSectionPos.getSectionCoord(boundingBox.getMinX()),ChunkSectionPos.getSectionCoord(boundingBox.getMinZ())),
                         new ChunkPos(ChunkSectionPos.getSectionCoord(boundingBox.getMaxX()),ChunkSectionPos.getSectionCoord(boundingBox.getMaxZ())),

--- a/src/main/java/net/ugi/sculk_depths/item/custom/crux_resonator/CruxResonator.java
+++ b/src/main/java/net/ugi/sculk_depths/item/custom/crux_resonator/CruxResonator.java
@@ -52,7 +52,6 @@ public class CruxResonator extends Item {
             itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST, new OscillatorTrackerComponentList(0, List.of()));
             return TypedActionResult.success(itemStack,false);
         }
-        System.out.println(oscillatorTrackerComponentList.selectedLocation());
         itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST, new OscillatorTrackerComponentList(oscillatorTrackerComponentList.selectedLocation() +1, oscillatorTrackerComponentList.trackers()));
         return TypedActionResult.success(itemStack,false);
     }
@@ -98,8 +97,6 @@ public class CruxResonator extends Item {
             if(oscillatorTrackerComponent1 != oscillatorTrackerComponent2) {
                 //System.out.println();
                 stack.set(ModComponentTypes.OSCILLATOR_TRACKER, oscillatorTrackerComponent2);
-                System.out.println(trackers);
-                System.out.println(selectedLocation);
                 trackers1.remove(selectedLocation);
                 if(selectedLocation == 0) {
                     stack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST, new OscillatorTrackerComponentList(selectedLocation, trackers1));
@@ -115,7 +112,6 @@ public class CruxResonator extends Item {
     @Override
     public ActionResult useOnBlock(ItemUsageContext context) {
         List<OscillatorTrackerComponent> trackers = new ArrayList<OscillatorTrackerComponent>();
-        System.out.println("START USE ON BLOCK");
 
         BlockPos blockPos = context.getBlockPos();
         World world = context.getWorld();
@@ -129,7 +125,6 @@ public class CruxResonator extends Item {
 
         if(itemStack.get(ModComponentTypes.OSCILLATOR_TRACKER_LIST) != null) {
             trackers = itemStack.get(ModComponentTypes.OSCILLATOR_TRACKER_LIST).trackers();
-            System.out.println("trackers:" + trackers);
         };
 
         OscillatorTrackerComponent oscillatorTrackerComponent = new OscillatorTrackerComponent(Optional.of(GlobalPos.create(world.getRegistryKey(), blockPos)), true, "");
@@ -143,8 +138,6 @@ public class CruxResonator extends Item {
         itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER , oscillatorTrackerComponent);
         itemStack.set(ModComponentTypes.OSCILLATOR_TRACKER_LIST , oscillatorTrackerComponentList);
 
-
-        System.out.println("END USE ON BLOCK");
 
         return ActionResult.success(world.isClient);
 


### PR DESCRIPTION
Normal play printed to the console: the Crux Resonator on every use, inventory tick and use-on-block; portal ignition once per structure child; and the client sound/wind path every world tick.

This removes the live `System.out.println` calls from those paths. Commented-out occurrences are left untouched.

Fixes #100

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
