### PR TITLE
fix(client): register the Quazarith shovel model

### DIFF
--- a/src/client/java/net/ugi/sculk_depths/SculkDepthsClient.java
+++ b/src/client/java/net/ugi/sculk_depths/SculkDepthsClient.java
@@ -55,7 +55,7 @@ public class SculkDepthsClient implements ClientModInitializer {
 		CustomItemModels.QuazarithAxeModels();
 		CustomItemModels.QuazarithPickaxeModels();
 		CustomItemModels.QuazarithHoeModels();
-		CustomItemModels.QuazarithSwordModels();
+		CustomItemModels.QuazarithShovelModels();
 		CustomItemModels.QuazarithHelmetModels();
 		CustomItemModels.QuazarithChestplateModels();
 		CustomItemModels.QuazarithLeggingsModels();


### PR DESCRIPTION
The client initializer called `QuazarithSwordModels()` twice and never called `QuazarithShovelModels()`, so the Quazarith Shovel's custom model predicates were never registered.

This replaces the duplicate sword call with the shovel one. The sword is still registered exactly once.

Fixes #102

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)
