### PR TITLE
fix: register the data-component types under sculk_depths instead of minecraft

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/item/ModComponentTypes.java
+++ b/src/main/java/net/ugi/sculk_depths/item/ModComponentTypes.java
@@ -3,13 +3,14 @@ package net.ugi.sculk_depths.item;
 import net.minecraft.component.ComponentType;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.ugi.sculk_depths.SculkDepths;
 import net.ugi.sculk_depths.item.custom.crux_resonator.OscillatorTrackerComponentList;
 import net.ugi.sculk_depths.item.custom.crux_resonator.OscillatorTrackerComponent;
 
 public class ModComponentTypes {
     public static void register(){
-        Registry.register(Registries.DATA_COMPONENT_TYPE, "quazarith_oscillator_tracker", OSCILLATOR_TRACKER);
-        Registry.register(Registries.DATA_COMPONENT_TYPE, "oscillator_tracker_list", OSCILLATOR_TRACKER_LIST);
+        Registry.register(Registries.DATA_COMPONENT_TYPE, SculkDepths.identifier("quazarith_oscillator_tracker"), OSCILLATOR_TRACKER);
+        Registry.register(Registries.DATA_COMPONENT_TYPE, SculkDepths.identifier("oscillator_tracker_list"), OSCILLATOR_TRACKER_LIST);
     }
 
     public static final ComponentType<OscillatorTrackerComponent> OSCILLATOR_TRACKER = ComponentType.<OscillatorTrackerComponent>builder().codec(OscillatorTrackerComponent.CODEC).packetCodec(OscillatorTrackerComponent.PACKET_CODEC).build();

--- a/src/test/java/net/ugi/sculk_depths/item/Issue99ComponentNamespaceTest.java
+++ b/src/test/java/net/ugi/sculk_depths/item/Issue99ComponentNamespaceTest.java
@@ -1,0 +1,35 @@
+package net.ugi.sculk_depths.item;
+
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+import net.ugi.sculk_depths.TestBootstrap;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression guard for issue #99: data-component types must be registered under the
+ * sculk_depths namespace, not the default minecraft namespace.
+ */
+class Issue99ComponentNamespaceTest {
+
+    @BeforeAll
+    static void setup() {
+        TestBootstrap.init();
+    }
+
+    @Test
+    void oscillatorTrackerComponentUsesModNamespace() {
+        Identifier id = Registries.DATA_COMPONENT_TYPE.getId(ModComponentTypes.OSCILLATOR_TRACKER);
+        assertEquals("sculk_depths", id.getNamespace(),
+                "quazarith_oscillator_tracker must be registered under the sculk_depths namespace");
+    }
+
+    @Test
+    void oscillatorTrackerListComponentUsesModNamespace() {
+        Identifier id = Registries.DATA_COMPONENT_TYPE.getId(ModComponentTypes.OSCILLATOR_TRACKER_LIST);
+        assertEquals("sculk_depths", id.getNamespace(),
+                "oscillator_tracker_list must be registered under the sculk_depths namespace");
+    }
+}


### PR DESCRIPTION
## Summary

The two data-component types were registered by passing a bare `String`, which `Identifier.of()` resolves against the default `minecraft` namespace — so they registered as `minecraft:quazarith_oscillator_tracker` and `minecraft:oscillator_tracker_list`. They now register through `SculkDepths.identifier(...)` like the rest of the mod, landing under `sculk_depths:`.

## Related Issues and Pull Requests

Fixes #99

Note: this targets `portal` rather than the default branch, so GitHub will not auto-close #99 on merge — it needs closing by hand.

## Changes

- `item/ModComponentTypes.java` — both `Registry.register` calls now pass `SculkDepths.identifier("…")` instead of a bare string; added the corresponding import. Nothing else in the file changed.
- Added `Issue99ComponentNamespaceTest` asserting both components resolve under the `sculk_depths` namespace.

## Testing

`./gradlew test` passes (JDK 21). `./gradlew build` passes. `./gradlew regressionTest` returns 0, though that task currently holds only a skipped stub unrelated to this issue, so it is not evidence either way here.

The new test reads the live registry — `Registries.DATA_COMPONENT_TYPE.getId(…).getNamespace()`, with the registry populated through the existing `TestBootstrap` — rather than comparing a literal against another literal.

Confirmed it actually bites: with the test kept and only `ModComponentTypes.java` restored to `portal`, both cases fail with

```
AssertionFailedError: quazarith_oscillator_tracker must be registered under the sculk_depths namespace ==> expected: <sculk_depths> but was: <minecraft>
```

and both pass again with the fix applied.

## Breaking Changes

**This changes the persisted identity of two components, and I do not think it is zero-impact — please sanity-check my reasoning before merging.**

A data-component type's registry id is the key it is serialized under on an ItemStack. After this change, a stack whose component data was written as `minecraft:quazarith_oscillator_tracker` no longer matches the registered `sculk_depths:` id, so that data reads as absent — silently, with no error.

My first read was that this is free, because no tagged release contains the code: `ModComponentTypes.java` was introduced in `d23ecf1` (2025-01-23), `git tag --contains` on it is empty, and the newest tag `0.0.11` predates it (2024-08-13). I no longer think that conclusion holds. Every published release is flagged *Pre-release*, the README points players at Discord for test builds, and CI has been building `portal` since 2025-06 — so code containing these components has been available to players for over a year through a channel tags do not track.

I cannot tell from outside whether anyone actually has an affected Crux Resonator. You can. If some do, this wants either a migration that reads the old id and rewrites it, or a note in the release announcement — both of which are yours to decide, so I have not attempted either here.

## Follow-ups / Known Limitations

The fix is verified at the registry level only. I have not verified in-game that an existing Crux Resonator behaves as expected across the change, since that is exactly the scenario above and it needs a world with pre-fix data in it.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation), Claude Sonnet 5 (verification)
