### PR TITLE
refactor(portal): PortalPhase enum, ArrayList frame growth, and direction-parameterized frame helpers

### DIFF
--- a/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
@@ -48,10 +48,20 @@ public class PedestalBlock extends FacingBlock {
     private static final VoxelShape RAYCAST_SHAPE = createCuboidShape(2.0, 4.0, 2.0, 14.0, 16.0, 14.0);
 
     private BlockPos[] portalFramePos = new BlockPos[0];
-    private String portalFase = "none";
+    private PortalPhase portalPhase = PortalPhase.NONE;
     private BlockPos[] posArray = new BlockPos[0];
     private ChunkPos[] chunkArray = new ChunkPos[0];
     private StructureStart structureStart;
+
+    public enum PortalPhase {
+        NONE,
+        CHECK_FRAME,
+        GEN_FRAME,
+        CANCEL_FRAME,
+        GEN_STRUCTURE,
+        WAITING_PARTICLES,
+        GEN_PORTAL
+    }
 
     protected static final VoxelShape OUTLINE_SHAPE = VoxelShapes.combineAndSimplify(
             VoxelShapes.union(createCuboidShape(0.0, 0.0, 0.0, 16.0, 2.0, 16.0),
@@ -87,7 +97,7 @@ public class PedestalBlock extends FacingBlock {
 
             BlockState blockState1 = state.with(HAS_ENERGY_ESSENCE, true);
             world.setBlockState(pos, blockState1);
-            portalFase = "checkFrame";
+            portalPhase = PortalPhase.CHECK_FRAME;
             world.scheduleBlockTick(pos,state.getBlock(),1);
             return ItemActionResult.SUCCESS;
         }
@@ -96,21 +106,21 @@ public class PedestalBlock extends FacingBlock {
 
     @Override
     public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        switch (portalFase){
-            case "checkFrame":
+        switch (portalPhase){
+            case CHECK_FRAME:
 
                 portalFramePos = Portal.getFramePos(state.get(FACING),pos, world);//todo benchmark
-                if (portalFramePos == null) {portalFase = "none";return;}
-                if (portalFramePos[0] == null) {portalFase = "none";return;}
+                if (portalFramePos == null) {portalPhase = PortalPhase.NONE;return;}
+                if (portalFramePos[0] == null) {portalPhase = PortalPhase.NONE;return;}
 
-                portalFase = "genFrame";
+                portalPhase = PortalPhase.GEN_FRAME;
                 posArray = portalFramePos;
 
                 world.scheduleBlockTick(pos,state.getBlock(),1);
                 break;
 
 
-            case "genFrame":
+            case GEN_FRAME:
 
                 posArray = Portal.genFrameStep(world, posArray, random);
                 if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 1){
@@ -119,22 +129,22 @@ public class PedestalBlock extends FacingBlock {
                         posArray = Portal.addElement(posArray,pos1.up(3));
                         posArray = Portal.addElement(posArray,pos1.up(4));
                     }
-                    portalFase = "genStructure";
+                    portalPhase = PortalPhase.GEN_STRUCTURE;
                 }
                 else if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
                     posArray = portalFramePos;
-                    portalFase = "cancelFrame";
+                    portalPhase = PortalPhase.CANCEL_FRAME;
                 }
                 world.scheduleBlockTick(pos,state.getBlock(),2);
                 break;
 
 
-            case "cancelFrame":
+            case CANCEL_FRAME:
 
                 posArray = Portal.cancelFrameStep(world,posArray);
                 if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
                     posArray = new BlockPos[0];
-                    portalFase = "none";
+                    portalPhase = PortalPhase.NONE;
                 }
                 else {
                     world.scheduleBlockTick(pos,state.getBlock(),2);
@@ -142,13 +152,13 @@ public class PedestalBlock extends FacingBlock {
                 break;
 
 
-            case "genStructure":
+            case GEN_STRUCTURE:
 
                 BlockPos anchor = Portal.getFrameAnchorPos(state.get(FACING),pos, world);
 
                 structureStart = GenerateStructureAPI.structureStart(world, ModDimensions.SCULK_DEPTHS_LEVEL_KEY, SculkDepths.identifier("portal_structure"), anchor); //50ms (matteo)
 
-                if (structureStart == null || !structureStart.hasChildren()) {portalFase = "none";return;}
+                if (structureStart == null || !structureStart.hasChildren()) {portalPhase = PortalPhase.NONE;return;}
 
                 BlockBox boundingBox = structureStart.getBoundingBox();
                 chunkArray = GenerateStructureAPI.generateChunkArray(//not laggy
@@ -174,7 +184,7 @@ public class PedestalBlock extends FacingBlock {
                     });
                 }
                 GenerateStructureAPI.generateStructurePartial(world, ModDimensions.SCULK_DEPTHS_LEVEL_KEY, SculkDepths.identifier("portal_structure"), structureStart, boundingBox.streamChunkPos().toArray(ChunkPos[]::new));
-                portalFase = "genPortal";
+                portalPhase = PortalPhase.GEN_PORTAL;
                 executorService.shutdown();
             });*/
 
@@ -188,14 +198,14 @@ public class PedestalBlock extends FacingBlock {
                 }, getAsyncExecutor()).thenRunAsync(() -> {
                     // This code runs back on the main server thread after the chunks are loaded
                     GenerateStructureAPI.generateStructurePartial(world, ModDimensions.SCULK_DEPTHS_LEVEL_KEY, SculkDepths.identifier("portal_structure"), structureStart, boundingBox.streamChunkPos().toArray(ChunkPos[]::new));
-                    portalFase = "genPortal";
+                    portalPhase = PortalPhase.GEN_PORTAL;
                 }, world.getServer());
-                portalFase = "waitingParticles";
+                portalPhase = PortalPhase.WAITING_PARTICLES;
                 world.scheduleBlockTick(pos,state.getBlock(),1);
                 break;
 
 
-            case "waitingParticles":
+            case WAITING_PARTICLES:
 
                 BlockPos posMin = Portal.getFrameMinPos(state.get(FACING),pos, world);
                 if (state.get(FACING) == Direction.NORTH)
@@ -212,16 +222,20 @@ public class PedestalBlock extends FacingBlock {
                 break;
 
 
-            case "genPortal":
+            case GEN_PORTAL:
 
                 posArray = Portal.genPortalStep(world,posArray,state.get(FACING), random);
                 if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
                     posArray = new BlockPos[0];
-                    portalFase = "none";
+                    portalPhase = PortalPhase.NONE;
                 }
                 else {
                     world.scheduleBlockTick(pos,state.getBlock(),2);
                 }
+                break;
+
+
+            default:
                 break;
         }
     }

--- a/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
+++ b/src/main/java/net/ugi/sculk_depths/block/custom/PedestalBlock.java
@@ -36,6 +36,7 @@ import net.ugi.sculk_depths.portal.Portal;
 import net.ugi.sculk_depths.state.property.ModProperties;
 import net.ugi.sculk_depths.world.dimension.ModDimensions;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,9 +48,9 @@ public class PedestalBlock extends FacingBlock {
     public static final MapCodec<PedestalBlock> CODEC = createCodec(PedestalBlock::new);
     private static final VoxelShape RAYCAST_SHAPE = createCuboidShape(2.0, 4.0, 2.0, 14.0, 16.0, 14.0);
 
-    private BlockPos[] portalFramePos = new BlockPos[0];
+    private List<BlockPos> portalFramePos = new ArrayList<>();
     private PortalPhase portalPhase = PortalPhase.NONE;
-    private BlockPos[] posArray = new BlockPos[0];
+    private List<BlockPos> posArray = new ArrayList<>();
     private ChunkPos[] chunkArray = new ChunkPos[0];
     private StructureStart structureStart;
 
@@ -111,7 +112,7 @@ public class PedestalBlock extends FacingBlock {
 
                 portalFramePos = Portal.getFramePos(state.get(FACING),pos, world);//todo benchmark
                 if (portalFramePos == null) {portalPhase = PortalPhase.NONE;return;}
-                if (portalFramePos[0] == null) {portalPhase = PortalPhase.NONE;return;}
+                if (portalFramePos.get(0) == null) {portalPhase = PortalPhase.NONE;return;}
 
                 portalPhase = PortalPhase.GEN_FRAME;
                 posArray = portalFramePos;
@@ -123,15 +124,15 @@ public class PedestalBlock extends FacingBlock {
             case GEN_FRAME:
 
                 posArray = Portal.genFrameStep(world, posArray, random);
-                if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 1){
-                    posArray = new BlockPos[0];
+                if (posArray.get(posArray.size() - 1).getY() == -4096 && posArray.get(posArray.size() - 1).getZ() == 1){
+                    posArray = new ArrayList<>();
                     for (BlockPos pos1: portalFramePos) {
-                        posArray = Portal.addElement(posArray,pos1.up(3));
-                        posArray = Portal.addElement(posArray,pos1.up(4));
+                        posArray.add(pos1.up(3));
+                        posArray.add(pos1.up(4));
                     }
                     portalPhase = PortalPhase.GEN_STRUCTURE;
                 }
-                else if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
+                else if (posArray.get(posArray.size() - 1).getY() == -4096 && posArray.get(posArray.size() - 1).getZ() == 0){
                     posArray = portalFramePos;
                     portalPhase = PortalPhase.CANCEL_FRAME;
                 }
@@ -142,8 +143,8 @@ public class PedestalBlock extends FacingBlock {
             case CANCEL_FRAME:
 
                 posArray = Portal.cancelFrameStep(world,posArray);
-                if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
-                    posArray = new BlockPos[0];
+                if (posArray.get(posArray.size() - 1).getY() == -4096 && posArray.get(posArray.size() - 1).getZ() == 0){
+                    posArray = new ArrayList<>();
                     portalPhase = PortalPhase.NONE;
                 }
                 else {
@@ -225,8 +226,8 @@ public class PedestalBlock extends FacingBlock {
             case GEN_PORTAL:
 
                 posArray = Portal.genPortalStep(world,posArray,state.get(FACING), random);
-                if (posArray[posArray.length -1].getY() == -4096 && posArray[posArray.length -1].getZ() == 0){
-                    posArray = new BlockPos[0];
+                if (posArray.get(posArray.size() - 1).getY() == -4096 && posArray.get(posArray.size() - 1).getZ() == 0){
+                    posArray = new ArrayList<>();
                     portalPhase = PortalPhase.NONE;
                 }
                 else {

--- a/src/main/java/net/ugi/sculk_depths/portal/Portal.java
+++ b/src/main/java/net/ugi/sculk_depths/portal/Portal.java
@@ -44,80 +44,56 @@ public class Portal {
         return list.toArray(new ChunkPos[0]);
     }
 
+    private static boolean hasPoweredPedestal(World world, BlockPos pos, Direction direction) {
+        BlockState state = world.getBlockState(pos.offset(direction, 10));
+        return state.getBlock() == ModBlocks.SCULK_PEDESTAL && state.get(ModProperties.HAS_ENERGY_ESSENCE);
+    }
+
     public static List<BlockPos> getFramePos(Direction pedestalFacing, BlockPos pos, World world ) {
-        switch (pedestalFacing) {
-            case EAST -> {
-                if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.north(6).up(6).west(5),pos.north(5).up(6).west(5));
-                if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.south(4).up(6).west(5),pos.south(5).up(6).west(5));
-            }
-            case NORTH -> {
-                if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.east(5).up(6).south(5),pos.east(4).up(6).south(5));
-                if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.west(5).up(6).south(5),pos.west(6).up(6).south(5));
-            }
-            case WEST -> {
-                if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.north(5).up(6).east(5),pos.north(4).up(6).east(5));
-                if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.south(5).up(6).east(5),pos.south(6).up(6).east(5));
-            }
-            case SOUTH -> {
-                if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.east(6).up(6).north(5),pos.east(5).up(6).north(5));
-                if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return List.of(pos.west(4).up(6).north(5),pos.west(5).up(6).north(5));
-            }
+        Direction right = pedestalFacing.rotateYClockwise();
+        Direction left = pedestalFacing.rotateYCounterclockwise();
+        if (hasPoweredPedestal(world, pos, right)) {
+            return getFramePositionsForSide(pos, pedestalFacing, right);
+        }
+        if (hasPoweredPedestal(world, pos, left)) {
+            return getFramePositionsForSide(pos, pedestalFacing, left);
         }
         return null;
     }
 
+    private static List<BlockPos> getFramePositionsForSide(BlockPos pos, Direction facing, Direction side) {
+        Direction depth = facing.getOpposite();
+        boolean isClockwise = side == facing.rotateYClockwise();
+        boolean facingPositiveAxis = facing == Direction.EAST || facing == Direction.SOUTH;
+        int a;
+        int b;
+        if (isClockwise) {
+            a = facingPositiveAxis ? 4 : 5;
+            b = facingPositiveAxis ? 5 : 4;
+        } else {
+            a = facingPositiveAxis ? 6 : 5;
+            b = 5;
+        }
+        return List.of(
+                pos.offset(depth, 5).up(6).offset(side, a),
+                pos.offset(depth, 5).up(6).offset(side, b)
+        );
+    }
+
     public static BlockPos getFrameAnchorPos(Direction pedestalFacing, BlockPos pos, World world ) {
-        switch (pedestalFacing) {
-            case EAST -> {
-                if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.north(5).up(13).west(5);
-                if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.south(5).up(13).west(5);
-            }
-            case NORTH -> {
-                if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.east(5).up(13).south(5);
-                if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.west(5).up(13).south(5);
-            }
-            case WEST -> {
-                if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.north(5).up(13).east(5);
-                if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.south(5).up(13).east(5);
-            }
-            case SOUTH -> {
-                if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.east(5).up(13).north(5);
-                if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
-                    if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return pos.west(5).up(13).north(5);
-            }
+        Direction right = pedestalFacing.rotateYClockwise();
+        Direction left = pedestalFacing.rotateYCounterclockwise();
+        if (hasPoweredPedestal(world, pos, right)) {
+            return getAnchorPosForSide(pos, pedestalFacing, right);
+        }
+        if (hasPoweredPedestal(world, pos, left)) {
+            return getAnchorPosForSide(pos, pedestalFacing, left);
         }
         return null;
+    }
+
+    private static BlockPos getAnchorPosForSide(BlockPos pos, Direction facing, Direction side) {
+        return pos.offset(side, 5).up(13).offset(facing.getOpposite(), 5);
     }
 
     public static List<BlockPos> getNextpos(BlockPos pos, World world, Block block){

--- a/src/main/java/net/ugi/sculk_depths/portal/Portal.java
+++ b/src/main/java/net/ugi/sculk_depths/portal/Portal.java
@@ -16,6 +16,8 @@ import net.ugi.sculk_depths.particle.ModParticleTypes;
 import net.ugi.sculk_depths.state.property.ModProperties;
 import net.ugi.sculk_depths.tags.ModTags;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static net.ugi.sculk_depths.block.custom.SculkDepthsPortalBlock.AXIS;
@@ -24,75 +26,57 @@ public class Portal {
 
 
     public static BlockPos[] addElement(BlockPos[] arr, BlockPos e) {
-        int n = arr.length;
-        BlockPos[] newarr = new BlockPos[n + 1];
-
-        for (int i = 0; i < n; i++){
-            newarr[i] = arr[i];
-        }
-
-        newarr[n] = e;
-        return newarr;
+        List<BlockPos> list = new ArrayList<>(Arrays.asList(arr));
+        list.add(e);
+        return list.toArray(new BlockPos[0]);
     }
 
     public static BlockPos[] addElement(BlockPos[] arr1, BlockPos[] arr2) {
-        int n = arr1.length;
-        int m = arr2.length;
-        BlockPos[] newarr = new BlockPos[n+m];
-
-        for (int i = 0; i < n; i++)
-            newarr[i] = arr1[i];
-
-        for (int i = 0; i < m; i++)
-            newarr[i+n] = arr2[i];
-        return newarr;
+        List<BlockPos> list = new ArrayList<>(arr1.length + arr2.length);
+        list.addAll(Arrays.asList(arr1));
+        list.addAll(Arrays.asList(arr2));
+        return list.toArray(new BlockPos[0]);
     }
 
     public static ChunkPos[] addElement(ChunkPos[] arr, ChunkPos e) {
-        int n = arr.length;
-        ChunkPos[] newarr = new ChunkPos[n + 1];
-
-        for (int i = 0; i < n; i++){
-            newarr[i] = arr[i];
-        }
-
-        newarr[n] = e;
-        return newarr;
+        List<ChunkPos> list = new ArrayList<>(Arrays.asList(arr));
+        list.add(e);
+        return list.toArray(new ChunkPos[0]);
     }
 
-    public static BlockPos[] getFramePos(Direction pedestalFacing, BlockPos pos, World world ) {
+    public static List<BlockPos> getFramePos(Direction pedestalFacing, BlockPos pos, World world ) {
         switch (pedestalFacing) {
             case EAST -> {
                 if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.north(6).up(6).west(5),pos.north(5).up(6).west(5)};
+                        return List.of(pos.north(6).up(6).west(5),pos.north(5).up(6).west(5));
                 if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.south(4).up(6).west(5),pos.south(5).up(6).west(5)};
+                        return List.of(pos.south(4).up(6).west(5),pos.south(5).up(6).west(5));
             }
             case NORTH -> {
                 if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.east(5).up(6).south(5),pos.east(4).up(6).south(5)};
+                        return List.of(pos.east(5).up(6).south(5),pos.east(4).up(6).south(5));
                 if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.west(5).up(6).south(5),pos.west(6).up(6).south(5)};
+                        return List.of(pos.west(5).up(6).south(5),pos.west(6).up(6).south(5));
             }
             case WEST -> {
                 if (world.getBlockState(pos.north(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.north(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.north(5).up(6).east(5),pos.north(4).up(6).east(5)};
+                        return List.of(pos.north(5).up(6).east(5),pos.north(4).up(6).east(5));
                 if (world.getBlockState(pos.south(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.south(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.south(5).up(6).east(5),pos.south(6).up(6).east(5)};
+                        return List.of(pos.south(5).up(6).east(5),pos.south(6).up(6).east(5));
             }
             case SOUTH -> {
                 if (world.getBlockState(pos.east(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.east(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.east(6).up(6).north(5),pos.east(5).up(6).north(5)};
+                        return List.of(pos.east(6).up(6).north(5),pos.east(5).up(6).north(5));
                 if (world.getBlockState(pos.west(10)).getBlock() == ModBlocks.SCULK_PEDESTAL)
                     if (world.getBlockState(pos.west(10)).get(ModProperties.HAS_ENERGY_ESSENCE))
-                        return new BlockPos[]{pos.west(4).up(6).north(5),pos.west(5).up(6).north(5)};
+                        return List.of(pos.west(4).up(6).north(5),pos.west(5).up(6).north(5));
             }
         }
         return null;
@@ -136,54 +120,54 @@ public class Portal {
         return null;
     }
 
-    public static BlockPos[] getNextpos(BlockPos pos, World world, Block block){
-        BlockPos[] arr = new BlockPos[0];
+    public static List<BlockPos> getNextpos(BlockPos pos, World world, Block block){
+        List<BlockPos> list = new ArrayList<>();
         if (world.getBlockState(pos.north()).getBlock() == block){
-            arr = addElement(arr,pos.north());
+            list.add(pos.north());
         }
         if (world.getBlockState(pos.south()).getBlock() == block){
-            arr = addElement(arr,pos.south());
+            list.add(pos.south());
         }
         if (world.getBlockState(pos.east()).getBlock() == block){
-            arr = addElement(arr,pos.east());
+            list.add(pos.east());
         }
         if (world.getBlockState(pos.west()).getBlock() == block){
-            arr = addElement(arr,pos.west());
+            list.add(pos.west());
         }
         if (world.getBlockState(pos.up()).getBlock() == block){
-            arr = addElement(arr,pos.up());
+            list.add(pos.up());
         }
         if (world.getBlockState(pos.down()).getBlock() == block){
-            arr = addElement(arr,pos.down());
+            list.add(pos.down());
         }
-        return arr;
+        return list;
     }
 
-    public static BlockPos[] getNextpos(BlockPos pos, World world, TagKey<Block> tag, Direction facing){
-        BlockPos[] arr = new BlockPos[0];
+    public static List<BlockPos> getNextpos(BlockPos pos, World world, TagKey<Block> tag, Direction facing){
+        List<BlockPos> list = new ArrayList<>();
         if (facing == Direction.EAST || facing == Direction.WEST){
             if (world.getBlockState(pos.north()).isIn(tag)){
-                arr = addElement(arr,pos.north());
+                list.add(pos.north());
             }
             if (world.getBlockState(pos.south()).isIn(tag)){
-                arr = addElement(arr,pos.south());
+                list.add(pos.south());
             }
         }
         if (facing == Direction.NORTH || facing == Direction.SOUTH){
             if (world.getBlockState(pos.east()).isIn(tag)){
-                arr = addElement(arr,pos.east());
+                list.add(pos.east());
             }
             if (world.getBlockState(pos.west()).isIn(tag)){
-                arr = addElement(arr,pos.west());
+                list.add(pos.west());
             }
         }
         if (world.getBlockState(pos.up()).isIn(tag)){
-            arr = addElement(arr,pos.up());
+            list.add(pos.up());
         }
         if (world.getBlockState(pos.down()).isIn(tag)){
-            arr = addElement(arr,pos.down());
+            list.add(pos.down());
         }
-        return arr;
+        return list;
     }
 
     private static Boolean checkFullFrame(BlockPos pos, World world){
@@ -217,47 +201,50 @@ public class Portal {
         return false;
     }
 
-    public static BlockPos[] genFrameStep(World world, BlockPos[] blockposses, Random random){
-        BlockPos[] newPosArr = {new BlockPos(0,-4096,0)};
+    public static List<BlockPos> genFrameStep(World world, List<BlockPos> blockposses, Random random){
+        List<BlockPos> newPosArr = new ArrayList<>();
+        newPosArr.add(new BlockPos(0,-4096,0));
         for (BlockPos pos: blockposses) {
-            BlockPos[] newPos = new BlockPos[0];
+            List<BlockPos> newPos = new ArrayList<>();
             if (world.getBlockState(pos).getBlock() != ModBlocks.ACTIVATED_AMALGAMITE) {
                 world.setBlockState(pos,ModBlocks.ACTIVATED_AMALGAMITE.getDefaultState());
                 Portal.addBlockPowerUpParticle((ServerWorld) world, pos, random, 10);
                     newPos = getNextpos(pos, world, Blocks.REINFORCED_DEEPSLATE);
-                if (newPos.length == 0){
+                if (newPos.isEmpty()){
                     if (checkFullFrame(pos,world))
-                        newPos = addElement(newPos,new BlockPos(0,-4096,1));
+                        newPos.add(new BlockPos(0,-4096,1));
                     else
-                        newPos = addElement(newPos,new BlockPos(0,-4096,0));
+                        newPos.add(new BlockPos(0,-4096,0));
                 }
-                newPosArr = addElement(newPosArr,newPos);
+                newPosArr.addAll(newPos);
             }
         }
         return newPosArr;
     }
 
-    public static BlockPos[] cancelFrameStep(World world, BlockPos[] blockposses){
-        BlockPos[] newPosArr = {new BlockPos(0,-4096,0)};
+    public static List<BlockPos> cancelFrameStep(World world, List<BlockPos> blockposses){
+        List<BlockPos> newPosArr = new ArrayList<>();
+        newPosArr.add(new BlockPos(0,-4096,0));
         for (BlockPos pos: blockposses) {
-            BlockPos[] newPos = new BlockPos[0];
+            List<BlockPos> newPos = new ArrayList<>();
             if (world.getBlockState(pos).getBlock() == ModBlocks.ACTIVATED_AMALGAMITE) {
                 world.setBlockState(pos,Blocks.REINFORCED_DEEPSLATE.getDefaultState());
                 newPos = getNextpos(pos, world, ModBlocks.ACTIVATED_AMALGAMITE);
-                if (newPos.length == 0){
-                    newPos = addElement(newPos,new BlockPos(0,-4096,0));
+                if (newPos.isEmpty()){
+                    newPos.add(new BlockPos(0,-4096,0));
                 }
-                newPosArr = addElement(newPosArr,newPos);
+                newPosArr.addAll(newPos);
             }
         }
         return newPosArr;
     }
 
-    public static BlockPos[] genPortalStep(World world, BlockPos[] blockposses, Direction facing, Random random){
+    public static List<BlockPos> genPortalStep(World world, List<BlockPos> blockposses, Direction facing, Random random){
         BlockState state = ModBlocks.SCULK_DEPTHS_PORTAL.getDefaultState();
-        BlockPos[] newPosArr = {new BlockPos(0,-4096,0)};
+        List<BlockPos> newPosArr = new ArrayList<>();
+        newPosArr.add(new BlockPos(0,-4096,0));
         for (BlockPos pos: blockposses) {
-            BlockPos[] newPos = new BlockPos[0];
+            List<BlockPos> newPos = new ArrayList<>();
             if (world.getBlockState(pos).getBlock() != ModBlocks.SCULK_DEPTHS_PORTAL) {
                 if (facing == Direction.NORTH || facing == Direction.SOUTH){
                     world.setBlockState(pos,ModBlocks.SCULK_DEPTHS_PORTAL.getStateWithProperties(state.with(AXIS, Direction.Axis.X)));
@@ -267,10 +254,10 @@ public class Portal {
                     world.setBlockState(pos,ModBlocks.SCULK_DEPTHS_PORTAL.getStateWithProperties(state.with(AXIS, Direction.Axis.Z)));
                     newPos = getNextpos(pos, world, ModTags.Blocks.PORTAL_AIR, facing);
                 }
-                if (newPos.length == 0){
-                    newPos = addElement(newPos,new BlockPos(0,-4096,0));
+                if (newPos.isEmpty()){
+                    newPos.add(new BlockPos(0,-4096,0));
                 }
-                newPosArr = addElement(newPosArr,newPos);
+                newPosArr.addAll(newPos);
             }
         }
         return newPosArr;

--- a/src/main/java/net/ugi/sculk_depths/portal/Portal.java
+++ b/src/main/java/net/ugi/sculk_depths/portal/Portal.java
@@ -72,7 +72,7 @@ public class Portal {
             b = facingPositiveAxis ? 5 : 4;
         } else {
             a = facingPositiveAxis ? 6 : 5;
-            b = 5;
+            b = facingPositiveAxis ? 5 : 6;
         }
         return List.of(
                 pos.offset(depth, 5).up(6).offset(side, a),

--- a/src/test/java/net/ugi/sculk_depths/portal/PortalFrameGeometryEquivalenceTest.java
+++ b/src/test/java/net/ugi/sculk_depths/portal/PortalFrameGeometryEquivalenceTest.java
@@ -1,0 +1,161 @@
+package net.ugi.sculk_depths.portal;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.ugi.sculk_depths.TestBootstrap;
+import net.ugi.sculk_depths.block.ModBlocks;
+import net.ugi.sculk_depths.state.property.ModProperties;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Equivalence tests for the refactored portal frame geometry helpers.
+ *
+ * <p>The expected values below are the verbatim pre-refactor expressions from
+ * upstream/portal, evaluated against the fixed origin {@code (10, 64, -7)}.
+ * They are hard-coded as plain coordinates so a change in either helper or its
+ * callers will fail here rather than silently drift.</p>
+ */
+class PortalFrameGeometryEquivalenceTest {
+
+    /**
+     * Deliberately asymmetric origin so that swapped axes or dropped signs show up.
+     */
+    private static final BlockPos ORIGIN = new BlockPos(10, 64, -7);
+
+    private static final BlockState POWERED_PEDESTAL;
+
+    static {
+        TestBootstrap.init();
+        POWERED_PEDESTAL = ModBlocks.SCULK_PEDESTAL.getDefaultState()
+                .with(ModProperties.HAS_ENERGY_ESSENCE, true);
+    }
+
+    private static World worldWithPoweredPedestalAt(BlockPos pedestalPos) {
+        World world = mock(World.class);
+        when(world.getBlockState(any(BlockPos.class))).thenReturn(Blocks.AIR.getDefaultState());
+        when(world.getBlockState(pedestalPos)).thenReturn(POWERED_PEDESTAL);
+        return world;
+    }
+
+    @Test
+    void eastNorthFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.north(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.EAST, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(5, 70, -13), frame.get(0), "east/north frame first corner");
+        assertEquals(new BlockPos(5, 70, -12), frame.get(1), "east/north frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.EAST, ORIGIN, world);
+        assertEquals(new BlockPos(5, 77, -12), anchor, "east/north anchor");
+    }
+
+    @Test
+    void eastSouthFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.south(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.EAST, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(5, 70, -3), frame.get(0), "east/south frame first corner");
+        assertEquals(new BlockPos(5, 70, -2), frame.get(1), "east/south frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.EAST, ORIGIN, world);
+        assertEquals(new BlockPos(5, 77, -2), anchor, "east/south anchor");
+    }
+
+    @Test
+    void northEastFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.east(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.NORTH, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(15, 70, -2), frame.get(0), "north/east frame first corner");
+        assertEquals(new BlockPos(14, 70, -2), frame.get(1), "north/east frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.NORTH, ORIGIN, world);
+        assertEquals(new BlockPos(15, 77, -2), anchor, "north/east anchor");
+    }
+
+    @Test
+    void northWestFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.west(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.NORTH, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(5, 70, -2), frame.get(0), "north/west frame first corner");
+        assertEquals(new BlockPos(4, 70, -2), frame.get(1), "north/west frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.NORTH, ORIGIN, world);
+        assertEquals(new BlockPos(5, 77, -2), anchor, "north/west anchor");
+    }
+
+    @Test
+    void westNorthFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.north(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.WEST, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(15, 70, -12), frame.get(0), "west/north frame first corner");
+        assertEquals(new BlockPos(15, 70, -11), frame.get(1), "west/north frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.WEST, ORIGIN, world);
+        assertEquals(new BlockPos(15, 77, -12), anchor, "west/north anchor");
+    }
+
+    @Test
+    void westSouthFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.south(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.WEST, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(15, 70, -2), frame.get(0), "west/south frame first corner");
+        assertEquals(new BlockPos(15, 70, -1), frame.get(1), "west/south frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.WEST, ORIGIN, world);
+        assertEquals(new BlockPos(15, 77, -2), anchor, "west/south anchor");
+    }
+
+    @Test
+    void southEastFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.east(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.SOUTH, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(16, 70, -12), frame.get(0), "south/east frame first corner");
+        assertEquals(new BlockPos(15, 70, -12), frame.get(1), "south/east frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.SOUTH, ORIGIN, world);
+        assertEquals(new BlockPos(15, 77, -12), anchor, "south/east anchor");
+    }
+
+    @Test
+    void southWestFrameMatchesOriginalOffsets() {
+        World world = worldWithPoweredPedestalAt(ORIGIN.west(10));
+
+        List<BlockPos> frame = Portal.getFramePos(Direction.SOUTH, ORIGIN, world);
+        assertNotNull(frame);
+        assertEquals(2, frame.size());
+        assertEquals(new BlockPos(6, 70, -12), frame.get(0), "south/west frame first corner");
+        assertEquals(new BlockPos(5, 70, -12), frame.get(1), "south/west frame second corner");
+
+        BlockPos anchor = Portal.getFrameAnchorPos(Direction.SOUTH, ORIGIN, world);
+        assertEquals(new BlockPos(5, 77, -12), anchor, "south/west anchor");
+    }
+}


### PR DESCRIPTION
## Summary

The three code-quality items from #103, in the portal code: the ignition state machine moves from a `String` field to an enum, `Portal`'s hand-grown `BlockPos[]` arrays become `ArrayList<BlockPos>`, and the duplicated directional offset blocks in `getFramePos` / `getFrameAnchorPos` collapse into direction-parameterized helpers. No gameplay behaviour is intended to change.

One commit per item, so any of the three can be dropped independently, plus a fourth adding the test described below.

## Related Issues and Pull Requests

Fixes #103

Base is `portal`, not the default branch, so GitHub will not auto-close #103 on merge — happy to close it by hand, or leave it to you.

## Changes

- `PedestalBlock.java` — new nested `public enum PortalPhase` (`NONE`, `CHECK_FRAME`, `GEN_FRAME`, `CANCEL_FRAME`, `GEN_STRUCTURE`, `WAITING_PARTICLES`, `GEN_PORTAL`) replacing the `String portalFase` field and its literal comparisons; the misspelling is fixed to `portalPhase` along the way. One enum constant per string literal that existed, with the same transitions and an added `default:` branch.
- `Portal.java` — `getNextpos`, `genFrameStep`, `cancelFrameStep`, `genPortalStep` and `getFramePos` now use `List<BlockPos>` instead of growing a new array per element. `PedestalBlock.portalFramePos` and `posArray` follow. Iteration order, duplicates and the `BlockPos(0, -4096, …)` sentinel positions are unchanged.
- `Portal.java` — extracted `hasPoweredPedestal(World, BlockPos, Direction)`, `getAnchorPosForSide(...)` and `getFramePositionsForSide(...)`, removing the repeated per-direction blocks.
- `PortalFrameGeometryEquivalenceTest.java` (new) — eight tests, one per facing/side combination, pinning `getFramePos` and `getFrameAnchorPos` against the pre-refactor coordinates.

`getFrameMinPos` is deliberately **not** collapsed — see Follow-ups.

## Testing

`./gradlew build` and `./gradlew test` are green; the pre-existing suite passes unchanged, and nothing in it was modified. `regressionTest` was not run or touched.

The frame geometry had no test coverage, and items 2 and 3 rewrite exactly that, so the fourth commit adds an equivalence test in the style of the existing `FluidLevelSamplerEquivalenceTest`. Expected values are hard-coded coordinates taken from the pre-refactor expressions on `portal` and evaluated at an asymmetric origin `(10, 64, -7)`, so a dropped or swapped axis shows up; they are not computed from the new helper.

**That test found a real bug in my own refactor before this PR was opened, which is the main reason it exists.** The first version of `getFramePositionsForSide` used a second-side offset of `5` for every counter-clockwise case, but the original expressions need `6` when the facing axis is negative — so NORTH and WEST portals would have had the wrong frame corner. `northWestFrameMatchesOriginalOffsets` and `westSouthFrameMatchesOriginalOffsets` failed, and the fix is `b = facingPositiveAxis ? 5 : 6`. All eight combinations now match the originals.

Mutation check: introducing a one-block error in the helper's depth offset turns all eight tests red. (Reverting `Portal.java` to `portal` wholesale does not compile against the new signatures, so that direction is a compile failure rather than an assertion failure.)

This is untested-by-CI gameplay geometry, so if you would rather verify the portal forms correctly in-game before merging, that is entirely reasonable — the test pins the coordinates against the old code, but only you can confirm the old coordinates were the ones you wanted.

## Breaking Changes

`Portal.getFramePos` now returns `List<BlockPos>` instead of `BlockPos[]`, and `genFrameStep` / `cancelFrameStep` / `genPortalStep` / `getNextpos` take and return lists. These are `public static` methods, so anything outside this mod calling them would need updating. Nothing inside the repo does, beyond the call sites updated here. Say the word if you would rather keep the array signatures and convert internally.

## Follow-ups / Known Limitations

- **`getFrameMinPos` is left exactly as it was.** Its offsets look asymmetric — an EAST-facing portal with a south-side pedestal offsets *north* — and I initially suspected a copy-paste error. Checking all eight combinations says otherwise: it returns the minimum corner of the particle spawn box that `WAITING_PARTICLES` extends along the positive axis (east for NORTH/SOUTH facings, south for EAST/WEST), and all eight are consistent with that one strategy. So it is intentional geometry, not a defect, and collapsing it would only re-encode the same table.
- **`Portal.addElement(...)` is now unreferenced by production code** — the list refactor removed its last caller, and it is reached only by the existing `PortalArrayLogicTest`. I left both the methods and their test untouched rather than widen this PR. Happy to remove them here or in a follow-up if you want them gone.
- `portalPhase` is still instance state on the `PedestalBlock` singleton. #90 proposes moving it to a BlockEntity; that is a much larger change and is not started here. The enum will move with it unchanged.

Generated by Claude Opus 5 (brief, review), Kimi K2.7 Code (implementation)
